### PR TITLE
Add -observe=<value> option to only watch specific containers

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	flag.StringVar(&config.tlsKey, "tlskey", config.tlsKey, "Path to client certificate private key")
 	flag.BoolVar(&config.verbose, "verbose", true, "Verbose output")
 	flag.IntVar(&config.ttl, "ttl", config.ttl, "TTL for matched requests")
+	flag.StringVar(&config.observeVal, "observe", config.observeVal, "Only match containers where DNSDOCK_OBSERVE == val")
 
 	var showVersion bool
 	if len(version) > 0 {


### PR DESCRIPTION
Only watch containers that have the DNSDOCK_OBSERVE environment
variable that matches the value give to -observe.